### PR TITLE
Convert u64 type to string when deserializing to JSON.

### DIFF
--- a/ts-sdk/src/types.ts
+++ b/ts-sdk/src/types.ts
@@ -57,7 +57,7 @@ export interface AddressData {
 }
 
 export interface TxOut {
-  value: number;
+  value: string;
   script_pubkey: string;
   runes: RuneAmount[];
   risky_runes: RuneAmount[];

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -19,6 +19,7 @@ brotli = { workspace = true }
 http = { workspace = true }
 ordinals = { workspace = true }
 serde = { workspace = true }
+serde_with = "3"
 thiserror = { workspace = true }
 hex = { workspace = true }
 uuid = { workspace = true }

--- a/types/src/tx_out.rs
+++ b/types/src/tx_out.rs
@@ -4,6 +4,7 @@ use {
     borsh::{BorshDeserialize, BorshSerialize},
     serde::{Deserialize, Serialize},
     std::io::{Read, Result, Write},
+    serde_with::{serde_as, DisplayFromStr}
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -84,10 +85,12 @@ impl<'de> Deserialize<'de> for SpentStatus {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TxOut {
     pub runes: Vec<RuneAmount>,
     pub risky_runes: Vec<RuneAmount>,
+    #[serde_as(as = "DisplayFromStr")]
     pub value: u64,
     pub spent: SpentStatus,
     pub script_pubkey: ScriptBuf,


### PR DESCRIPTION
Implemented a way do deserialize u64 type from the Rust struct to string type in JSON (by default, serde library converts it to number type, which may lead to loss of precision).