### PR TITLE
Implements memory-based dynamic cache flushing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,7 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.9",
  "threadpool",
- "titan-types 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "titan-types 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tower-http",
  "tracing",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "titan-client"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -2701,7 +2701,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.9",
- "titan-types 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "titan-types 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "titan-types"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "titan-types"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7ef73b29694e2efd99aee5fbce51d9f95acb36ea06779d3c6fd25bc9d63aa3"
+checksum = "acd41b20e33ff1ecb13726da0507df4a40f3888bf9271e6b7d78544ed940f7a7"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 # workspace
-titan-types = { version = "0.1.30" }
+titan-types = { version = "0.1.31" }
 
 async-trait = "0.1.86"
 axum = "0.8.1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "titan-client"
-version = "0.1.47"
+version = "0.1.48"
 edition = "2021"
 
 authors = ["Marcos <mcolladomcm@email.com>"]

--- a/indexer/src/index/settings.rs
+++ b/indexer/src/index/settings.rs
@@ -19,6 +19,8 @@ pub struct Settings {
     pub(crate) index_addresses: bool,
     pub(crate) main_loop_interval: u64,
     pub(crate) memory_flush_ratio: f64,
+    pub(crate) memory_resume_ratio: f64,
+    pub(crate) memory_refresh_ms: u64,
 }
 
 impl RpcClientProvider for Settings {

--- a/indexer/src/index/settings.rs
+++ b/indexer/src/index/settings.rs
@@ -17,8 +17,8 @@ pub struct Settings {
     pub(crate) index_bitcoin_transactions: bool,
     pub(crate) index_spent_outputs: bool,
     pub(crate) index_addresses: bool,
-    pub(crate) commit_interval: u64,
     pub(crate) main_loop_interval: u64,
+    pub(crate) memory_flush_ratio: f64,
 }
 
 impl RpcClientProvider for Settings {

--- a/indexer/src/index/updater/cache/block_cache.rs
+++ b/indexer/src/index/updater/cache/block_cache.rs
@@ -347,10 +347,6 @@ impl BlockCache {
         }
     }
 
-    pub fn should_flush(&self, max_size: usize) -> bool {
-        self.update.blocks.len() >= max_size
-    }
-
     pub fn flush(&mut self) -> Result<()> {
         info!(
             "Block cache: outpoints: {:?}, spent_outpoints: {:?}, blocks: {:?}",

--- a/indexer/src/options.rs
+++ b/indexer/src/options.rs
@@ -124,6 +124,22 @@ pub struct Options {
     )]
     pub(super) memory_flush_ratio: f64,
 
+    /// Memory resume ratio (0.0-1.0). Resume processing when usage <= ratio.
+    #[arg(
+        long,
+        help = "Resume processing when memory usage drops to this ratio or below. [default: 0.75]",
+        default_value = "0.75"
+    )]
+    pub(super) memory_resume_ratio: f64,
+
+    /// Memory refresh interval in milliseconds.
+    #[arg(
+        long,
+        help = "Minimum interval between memory checks in milliseconds. [default: 250]",
+        default_value = "250"
+    )]
+    pub(super) memory_refresh_ms: u64,
+
     /// Enable zmq listener. This optimizes the mempool indexing process because
     /// we don't need to fetch transactions from the RPC.
     #[arg(long, default_value = "false")]
@@ -209,6 +225,8 @@ impl From<Options> for Settings {
             index_addresses: options.index_addresses,
             main_loop_interval: options.main_loop_interval,
             memory_flush_ratio: options.memory_flush_ratio,
+            memory_resume_ratio: options.memory_resume_ratio,
+            memory_refresh_ms: options.memory_refresh_ms,
         }
     }
 }

--- a/indexer/src/options.rs
+++ b/indexer/src/options.rs
@@ -116,13 +116,13 @@ pub struct Options {
     )]
     pub(super) index_addresses: bool,
 
-    /// Commit interval in blocks. [default: 500]
+    /// Memory flush ratio (0.0-1.0). Flush when memory used >= ratio of limit/total.
     #[arg(
         long,
-        help = "Commit interval in blocks. [default: 50]",
-        default_value = "50"
+        help = "Flush when memory usage reaches this ratio of the limit (0.0-1.0). [default: 0.85]",
+        default_value = "0.85"
     )]
-    pub(super) commit_interval: u64,
+    pub(super) memory_flush_ratio: f64,
 
     /// Enable zmq listener. This optimizes the mempool indexing process because
     /// we don't need to fetch transactions from the RPC.
@@ -207,8 +207,8 @@ impl From<Options> for Settings {
             index_bitcoin_transactions: options.index_bitcoin_transactions,
             index_spent_outputs: options.index_spent_outputs,
             index_addresses: options.index_addresses,
-            commit_interval: options.commit_interval,
             main_loop_interval: options.main_loop_interval,
+            memory_flush_ratio: options.memory_flush_ratio,
         }
     }
 }

--- a/indexer/src/util/memory.rs
+++ b/indexer/src/util/memory.rs
@@ -1,0 +1,137 @@
+use std::{fs, time::{Duration, Instant}};
+
+#[derive(Debug, Clone, Copy)]
+pub struct MemorySnapshot {
+    pub total_bytes: u64,
+    pub used_bytes: u64,
+    pub process_rss_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryLimiterSettings {
+    /// Trigger flush when used >= total * ratio
+    pub flush_ratio: f64,
+    /// Minimum interval between expensive reads
+    pub min_refresh_interval: Duration,
+}
+
+impl Default for MemoryLimiterSettings {
+    fn default() -> Self {
+        Self {
+            flush_ratio: 0.80,
+            min_refresh_interval: Duration::from_millis(250),
+        }
+    }
+}
+
+pub struct MemoryLimiter {
+    settings: MemoryLimiterSettings,
+    last_snapshot: Option<(Instant, MemorySnapshot)>,
+}
+
+impl MemoryLimiter {
+    pub fn new(settings: MemoryLimiterSettings) -> Self {
+        Self { settings, last_snapshot: None }
+    }
+
+    pub fn should_flush(&mut self) -> bool {
+        let snap = self.snapshot();
+        if let Some(snap) = snap {
+            if snap.total_bytes > 0 {
+                let used_ratio = (snap.used_bytes as f64) / (snap.total_bytes as f64);
+                return used_ratio >= self.settings.flush_ratio;
+            }
+        }
+        false
+    }
+
+    pub fn snapshot(&mut self) -> Option<MemorySnapshot> {
+        let now = Instant::now();
+        if let Some((t, snap)) = self.last_snapshot {
+            if now.duration_since(t) < self.settings.min_refresh_interval {
+                return Some(snap);
+            }
+        }
+
+        let snap = read_memory_snapshot();
+        if let Some(s) = snap {
+            self.last_snapshot = Some((now, s));
+        }
+        snap
+    }
+}
+
+fn read_memory_snapshot() -> Option<MemorySnapshot> {
+    // Try cgroup v2 memory limits first (common in containers/k8s)
+    if let Some(cg) = read_cgroup_v2_memory() {
+        return Some(cg);
+    }
+
+    // Fall back to system MemTotal/MemAvailable and process RSS
+    let (total, available) = read_proc_meminfo()?;
+    let rss = read_process_rss_bytes().unwrap_or(0);
+    let used = total.saturating_sub(available);
+    Some(MemorySnapshot { total_bytes: total, used_bytes: used, process_rss_bytes: rss })
+}
+
+fn read_cgroup_v2_memory() -> Option<MemorySnapshot> {
+    // memory.max may be "max" if unlimited
+    let max_path = "/sys/fs/cgroup/memory.max";
+    let current_path = "/sys/fs/cgroup/memory.current";
+    let limit = fs::read_to_string(max_path).ok()?.trim().to_string();
+    let current = fs::read_to_string(current_path).ok()?.trim().to_string();
+
+    let current_bytes: u64 = current.parse().ok()?;
+    let total_bytes: u64 = if limit == "max" { 0 } else { limit.parse().ok()? };
+
+    // If total is unknown (unlimited), derive from host MemTotal
+    let total_bytes = if total_bytes == 0 {
+        read_proc_meminfo()?.0
+    } else {
+        total_bytes
+    };
+
+    let rss = read_process_rss_bytes().unwrap_or(0);
+    Some(MemorySnapshot { total_bytes, used_bytes: current_bytes, process_rss_bytes: rss })
+}
+
+fn read_proc_meminfo() -> Option<(u64, u64)> {
+    let content = fs::read_to_string("/proc/meminfo").ok()?;
+    let mut total_kb: Option<u64> = None;
+    let mut available_kb: Option<u64> = None;
+    for line in content.lines() {
+        if line.starts_with("MemTotal:") {
+            total_kb = extract_kb(line);
+        } else if line.starts_with("MemAvailable:") {
+            available_kb = extract_kb(line);
+        }
+        if total_kb.is_some() && available_kb.is_some() {
+            break;
+        }
+    }
+    let total = total_kb? * 1024;
+    let available = available_kb? * 1024;
+    Some((total, available))
+}
+
+fn extract_kb(line: &str) -> Option<u64> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() >= 2 {
+        return parts[1].parse::<u64>().ok();
+    }
+    None
+}
+
+fn read_process_rss_bytes() -> Option<u64> {
+    let content = fs::read_to_string("/proc/self/status").ok()?;
+    for line in content.lines() {
+        if line.starts_with("VmRSS:") {
+            if let Some(kb) = extract_kb(line) {
+                return Some(kb * 1024);
+            }
+        }
+    }
+    None
+}
+
+

--- a/indexer/src/util/mod.rs
+++ b/indexer/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub use into_usize::IntoUsize;
 
 mod into_usize;
+pub mod memory;

--- a/ts-sdk/package-lock.json
+++ b/ts-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@titanbtcio/sdk",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@titanbtcio/sdk",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT or Apache-2.0",
       "dependencies": {
         "axios": "^1.7.9"

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanbtcio/sdk",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "SDK for Titan BTC indexer",
   "author": "Saturn BTC",
   "publishConfig": {

--- a/ts-sdk/src/types.ts
+++ b/ts-sdk/src/types.ts
@@ -49,6 +49,8 @@ export interface AddressTxOut extends OutPoint {
   risky_runes: RuneAmount[];
   status: TransactionStatus;
   spent: SpentStatus;
+  size: number;
+  weight: number;
 }
 
 export interface AddressData {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "titan-types"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 
 authors = ["Marcos <mcolladomcm@email.com>"]

--- a/types/src/address.rs
+++ b/types/src/address.rs
@@ -22,6 +22,8 @@ pub struct AddressTxOut {
     pub risky_runes: Vec<RuneAmount>,
     pub spent: SpentStatus,
     pub status: TransactionStatus,
+    pub size: u64,
+    pub weight: u64,
 }
 
 impl From<(SerializedOutPoint, TxOut, TransactionStatus)> for AddressTxOut {
@@ -36,6 +38,38 @@ impl From<(SerializedOutPoint, TxOut, TransactionStatus)> for AddressTxOut {
             risky_runes: tx_out.risky_runes,
             spent: tx_out.spent,
             status,
+            size: 0,
+            weight: 0,
+        }
+    }
+}
+
+impl From<(
+        SerializedOutPoint,
+        TxOut,
+        TransactionStatus,
+        u64,
+        u64,
+    )> for AddressTxOut {
+    fn from(
+        (outpoint, tx_out, status, size, weight): (
+            SerializedOutPoint,
+            TxOut,
+            TransactionStatus,
+            u64,
+            u64,
+        ),
+    ) -> Self {
+        Self {
+            txid: outpoint.to_txid(),
+            vout: outpoint.vout(),
+            value: tx_out.value,
+            runes: tx_out.runes,
+            risky_runes: tx_out.risky_runes,
+            spent: tx_out.spent,
+            status,
+            size,
+            weight,
         }
     }
 }


### PR DESCRIPTION
Replaces the fixed block commit interval with a dynamic memory-based flushing mechanism.

The indexer now monitors memory usage and flushes the cache when it reaches a certain ratio of the total available memory. This helps prevent out-of-memory errors and improves stability.

A new `MemoryLimiter` struct is introduced to manage memory snapshots and determine when to flush.
The flush ratio is configurable via the `memory_flush_ratio` option.

Removes the old `commit_interval` setting as it is no longer used.
